### PR TITLE
fixed UnicodeEncodeError

### DIFF
--- a/mpns/notification.py
+++ b/mpns/notification.py
@@ -36,7 +36,10 @@ class MPNSBase(object):
     def serialize_tree(self, tree):
         file = io.BytesIO()
         tree.write(file, encoding='utf-8')
-        contents = "<?xml version='1.0' encoding='utf-8'?>" + file.getvalue()
+        contents = ''.join((
+            "<?xml version='1.0' encoding='utf-8'?>",
+            file.getvalue(),
+        ))
         file.close()
         return contents
 

--- a/mpns/notification.py
+++ b/mpns/notification.py
@@ -36,7 +36,7 @@ class MPNSBase(object):
     def serialize_tree(self, tree):
         file = io.BytesIO()
         tree.write(file, encoding='utf-8')
-        contents = "<?xml version='1.0' encoding='utf-8'?>" + file.getvalue().decode('utf-8')
+        contents = "<?xml version='1.0' encoding='utf-8'?>" + file.getvalue()
         file.close()
         return contents
 


### PR DESCRIPTION
Fixed the next exception:

```
>>> from mpns import MPNSToast
>>> token='http://db3.notify.live.net/throttledthirdparty/01.00........'
>>> srv = MPNSToast()
>>> res = srv.send(token, {'text1':u'Тест русского'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mpns/notification.py", line 136, in send
    res = requests.post(uri, data=data, headers=self.headers, cert=cert)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 88, in post
    return request('post', url, data=data, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 455, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 558, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 330, in send
    timeout=timeout
  File "/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py", line 557, in urlopen
    body=body, headers=headers)
  File "/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py", line 382, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python2.7/httplib.py", line 973, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1007, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 969, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 833, in _send_output
    self.send(message_body)
  File "/usr/lib/python2.7/httplib.py", line 805, in send
    self.sock.sendall(data)
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 101-104: ordinal not in range(128)
>>> 
```
